### PR TITLE
Update deprecated (and removed) get_read_array call

### DIFF
--- a/descale_verify.py
+++ b/descale_verify.py
@@ -46,7 +46,7 @@ def get_statistics(clip):
     for i in range(clip.num_frames):
         frame = clip.get_frame(i)
         # read the first plane into numpy array
-        np_array = np.array(frame.get_read_array(0))
+        np_array = np.array(frame[0])
         # you may change the formula here
         values[i] = np.sum(np.abs(np_array))
         print('\r' + str(i + 1) + '/' + str(clip.num_frames), end='', flush=True)


### PR DESCRIPTION
VapourSynth removed a bunch of deprecated functions including get_read_array, this just replaces that with the new alternative.